### PR TITLE
Initial settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,11 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
# What
本番環境に不要なファイルを含めないための設定の追加。

# Why
ファイル量が増えると管理が大変になるため、railsコマンドで余分なファイルを生成しないようにした。
またテストとしてアップロードしたものは本番環境で不要であるため、.gitignoreにより除外した。